### PR TITLE
persistencia de salud e inventario mediante PlayerData

### DIFF
--- a/Assets/Scenes/Level 1/Cabins/Cabin1.unity
+++ b/Assets/Scenes/Level 1/Cabins/Cabin1.unity
@@ -1209,123 +1209,6 @@ RectTransform:
   m_AnchoredPosition: {x: 321, y: -192}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &737706948
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 8941051116669147598, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9119325911928087624, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
-      propertyPath: orthographic size
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 29571470129168884, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_Size.x
-      value: 0.900609
-      objectReference: {fileID: 0}
-    - target: {fileID: 29571470129168884, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_Size.y
-      value: 1.7451289
-      objectReference: {fileID: 0}
-    - target: {fileID: 29571470129168884, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.0065631866
-      objectReference: {fileID: 0}
-    - target: {fileID: 29571470129168884, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_Offset.y
-      value: -0.72743547
-      objectReference: {fileID: 0}
-    - target: {fileID: 141754545030144857, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: moveSpeed
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 141754545030144857, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: meleeUnlockItem
-      value: 
-      objectReference: {fileID: 11400000, guid: 29043914075957840949e1fcd6737264, type: 2}
-    - target: {fileID: 141754545030144857, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: rangedUnlockItem
-      value: 
-      objectReference: {fileID: 11400000, guid: 29043914075957840949e1fcd6737264, type: 2}
-    - target: {fileID: 2556796006519688224, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_SortingLayer
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2556796006519688224, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_SortingOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2556796006519688224, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_SortingLayerID
-      value: 2076560267
-      objectReference: {fileID: 0}
-    - target: {fileID: 2729704582954218501, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_Name
-      value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6341350933494934599, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8459196473299158479, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_BackGroundColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8459196473299158479, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_BackGroundColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8459196473299158479, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-      propertyPath: m_BackGroundColor.r
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
 --- !u!1 &778186310
 GameObject:
   m_ObjectHideFlags: 0
@@ -1821,7 +1704,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73365a6f6ba35f24baed9ceab57cc169, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Hud: {fileID: 2085592996}
 --- !u!4 &1316499236
 Transform:
   m_ObjectHideFlags: 0
@@ -1957,6 +1839,63 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &1712520589
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.9318714
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.0694633
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531211341117968607, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5655322108261420855, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
 --- !u!1 &1755828782
 GameObject:
   m_ObjectHideFlags: 0
@@ -2287,8 +2226,8 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 2085592997}
+  - {fileID: 1712520589}
   - {fileID: 1316499236}
-  - {fileID: 737706948}
   - {fileID: 72546990}
   - {fileID: 973284451}
   - {fileID: 1852877573}

--- a/Assets/Scenes/Level 1/Map/Scene1.unity
+++ b/Assets/Scenes/Level 1/Map/Scene1.unity
@@ -3272,6 +3272,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1284971875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1284971877}
+  - component: {fileID: 1284971876}
+  m_Layer: 0
+  m_Name: PlayerData
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1284971876
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1284971875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1afa33047bb7d02468b9144b4fa56f87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentHealth: 100
+  maxHealth: 100
+--- !u!4 &1284971877
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1284971875}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1289864413
 GameObject:
   m_ObjectHideFlags: 0
@@ -44989,6 +45035,7 @@ SceneRoots:
   m_Roots:
   - {fileID: 1904020778}
   - {fileID: 8303893787154437269}
+  - {fileID: 1284971877}
   - {fileID: 2042380024}
   - {fileID: 1996874513}
   - {fileID: 1954659843}

--- a/Assets/Scenes/Templates/Cabin.scenetemplate
+++ b/Assets/Scenes/Templates/Cabin.scenetemplate
@@ -17,13 +17,9 @@ MonoBehaviour:
   description: 
   preview: {fileID: 0}
   dependencies:
-  - dependency: {fileID: 7400000, guid: 95a09327a3cfbc34e914da39ab1ac7ff, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: f6046bcee4966b64d831462c6db4a098, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: b9aab6a41102a324eb85dbb283a40d76, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: c0c107e4a0d5ad44db01cc140f365bab, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: ef8f8233c98a7d748886e0f42f5bd833, type: 2}
     instantiationMode: 1
@@ -31,8 +27,12 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: e6eee8e01b0935144bbde09e6e63e19f, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: ba6aa6d8ed98d0340bddded9a3d9b1dd, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: bb81125505aed3d42aaaaa4fc64055e0, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: f2f16791b6447cc4bbfd1a67674e7f8f, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 8c86986c88ab7b945a09f68d43f152cb, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: b00b690f5a4ee8a44b617fc8851176d1, type: 2}
@@ -43,19 +43,29 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 7ffef287c45779c4fa8e1e0d655d3175, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 8c967f47f9109864c884ecf9cacfa54a, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: fd814c1275efa6b46b46215e82b204b1, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2729704582954218501, guid: ec3b8700a16e8da48a8b515d524a4083, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ba50595135066364eaf65f88085743ec, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 4b330c20aaeae9d4ebccb04853d38cf4, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2729704582954218501, guid: 8f5ffcca60f878a429c6b04cfbc8d8cc, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 6ee2ee175640b4945bfae80a9f668c82, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 9100000, guid: 5dd88e9ca2407ef4889f0a7fc3afd532, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: aa46f1391a1f51345819d0ead6c9d476, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 9467cec2ba97d71498e5d9adeadd1daa, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 04448b644e4556142b49b082a3e42fa5, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: 9467cec2ba97d71498e5d9adeadd1daa, type: 3}
+  - dependency: {fileID: 2800000, guid: e2bce7decafb87c4e8e860fa46b1d74b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 96ec8039c1bd94f4b9bf836bc4892cf2, type: 2}
     instantiationMode: 1
@@ -63,21 +73,21 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 102900000, guid: 659ffb14cad9b1c4abbf0339ed42df1c, type: 3}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: f2990907003226945bf0aac8b7fed977, type: 2}
+  - dependency: {fileID: 2800000, guid: 638d70a808126a846b21351028a3a864, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 877648ad985e98d4d95985f15de43ea4, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: 638d70a808126a846b21351028a3a864, type: 3}
-    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 17791d1905f4e6a41a6226f54efd48c3, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: ef36a2c974cb78d4581b0e242f1e8f52, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: d8a13ecff129e404bb081fda082d35e0, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: ca10f4b1df8bc6e419588b523b0a0ab7, type: 3}
+  - dependency: {fileID: 7400000, guid: bbb0d8b7914cc1342829f67d3ef99bb0, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: dffc59400e50fd2449ef9b8c93365e01, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: ca10f4b1df8bc6e419588b523b0a0ab7, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: cdcbf347b19e42d469efa62c7f96df4c, type: 2}
     instantiationMode: 1
@@ -87,17 +97,21 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 3e3e6fc54499da34ba864b9ce5f1510a, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 8d359591b04e203428b737cf2bed826b, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 60d16e69c7dc6bd449733a8ffd5edc78, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 11400000, guid: e1c9f072e9492be4d82feaf26fff81da, type: 2}
-    instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: dca07b27238e1e64ab3b91cdfe2a3ece, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 5b67b5ab9c6b6e54e992700b72ffa762, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: a1742495389eea34284d00bda5b44329, type: 3}
-    instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: e1c9f072e9492be4d82feaf26fff81da, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 4511971168175405730, guid: 372ea1acfb45907458cc64244676fdcb, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 4750d63b32557754fa5a7d2dc37cca7e, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 086996ba587eb5440be447cfaa9efd65, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 102900000, guid: a8ab21223c6cab447bb21975ca3fa9a1, type: 3}
     instantiationMode: 1
@@ -105,19 +119,23 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 7400000, guid: cb77b1de492905b44b174d290219554e, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: 607b98decb80bd34783b25a9892c61d9, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 7400000, guid: 423fde4042e64344faeef64b2a374ffe, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 4cf073d2e3cb0f142bc2e10d87aecd71, type: 3}
+  - dependency: {fileID: 2800000, guid: fb7e471c632237a42ae2368001e3e03c, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: f53ceacfc7b62d34593c9e329004e4db, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 0a48b4c7a00848648a1fdb176211f141, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: f0e388054b57884449dc0b74d0f3f3da, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 0871bf524a4dad444a0f78799af6d3e7, type: 3}
+  - dependency: {fileID: 7400000, guid: 279d4bb9d9b3db84d929cc81f0c9c2b7, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 16e0aa07ef3de6248ae093f2c44844e8, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: f0e388054b57884449dc0b74d0f3f3da, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 5246f45917596f3499039b1d4c878625, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 8a9796e5bc82a8a489a8a63f47321c69, type: 3}
     instantiationMode: 0
@@ -127,6 +145,10 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: cbfc33e7fecaf544bb497b1aced0caf9, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 0255a393a0f5dbc4c9bcbe716b1130e7, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: ee909038b270da94095fcb8854dc19b4, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 3341f50f5f026f448b35e452c0762b37, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 63b22782bab3703469d00cb97f1ef5ac, type: 2}
@@ -145,10 +167,22 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 5d19f3d4967599b4d8ac2379403563d7, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2039325003126953774, guid: 8c2e7c5e15a5cf24c8c8f454153f6785, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 94378a3044a9c84489fb066fa606b5d7, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: e606e399d65521f49b5c222c1010f644, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: e0d2f88869ecb9f45bf116e5b7a6c63c, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 5e73b0db6e9ab32439f29632628006af, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 1d6cd31dfb58fb34488e8611a2ed27c6, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: c871c9f2215d48c4a9f554fd767aa753, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: fc106a91e8d8ce14594d75b8b759d3c6, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 9e69d773fbfafab479316cf9c8e0c872, type: 2}
@@ -163,11 +197,13 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 664c78ab7b6e44148871a5864333a08a, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 102900000, guid: c9f2899c9a60af142b76cf2140fb1bbc, type: 3}
+  - dependency: {fileID: 11400000, guid: 5ccff41952318514ca5033bed7e82e23, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: d3012252af14a9e4488ad95769f06772, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: 4b383520b9b17834e8e14ddde388184c, type: 3}
+  - dependency: {fileID: 102900000, guid: c9f2899c9a60af142b76cf2140fb1bbc, type: 3}
+    instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: daddd7725b4c3a447a8a1a6191ae9e3b, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 55a7223a1ac803d4f9f8f4275eda32eb, type: 3}
     instantiationMode: 0
@@ -185,13 +221,17 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2729704582954218501, guid: ffbac23bf453f8945be82b63b90240f1, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 4b383520b9b17834e8e14ddde388184c, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 9a463208625baf34ca9a595fc299712b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 6a7000791dbb6fc4897ca602a3a9785b, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: 0338040b88e60ea4ebfc03ec909f27e5, type: 3}
+  - dependency: {fileID: 7400000, guid: fbff761054215c245b633a2bba8388af, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 07a237ed698be9845b01701795f886f5, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 28159c00cc034ed4495353de630dfa7b, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 1661301611125576216, guid: 893fca5620d88574cae1ae852af70f0a, type: 3}
     instantiationMode: 0
@@ -199,11 +239,15 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: de414e49cdcd1af41a4afeda69f8fc58, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: b47ec6c2c29333043acd1e8c95dad37a, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 9e40fd635ab666e4aba796aed8b2887d, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 78e28dd3ec24d9b4b8f4d001d666a193, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 9100000, guid: 8cdc26592fd8a7646b64012dbfe71d9d, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: eb2ca74c4b656ff4fb8c99a2232e2c32, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 0a658986e9f28a744a1cff729becb1a4, type: 3}
     instantiationMode: 0
@@ -215,13 +259,21 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 2e0b6df372f856e47be188d537f90a3f, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 711c15b744a35c14f9e16fe487802200, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: bee55c08a36d7564d9cd67480ba9634a, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: c719b0705dd2fb740a40b9690988e08d, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: ce6a279d75cbcd04fad1401c1a2ead83, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: f9a044bbb7cbd5044bda5859594081d9, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: e32e755643cf50e4185cce56b5a4e662, type: 2}
+  - dependency: {fileID: 2800000, guid: 4607a56819736ca4db96d3f796ba1c8e, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: a9398449b4607294cb14a5c8a01804be, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 8099010386522153881, guid: 04f5cc7bd4e72834bb869238445841b2, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 004fe84d59fda59448fd46788c3130cb, type: 2}
     instantiationMode: 1
@@ -229,14 +281,22 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: dcfd61a24bc28dc4e9fa14d68153749e, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 5570859099633080184, guid: bdfb0d870284dd34280c874a2dec4a6b, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 9fde2d7e9bdb60640945a72a081269a0, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: f411cd430d7456c45b51b301cbdb3ec2, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 436d85106db31f84fb1eb4e2b0d127a7, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 4be7f859593ce2242b05d4b8bfbb82fc, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 98dbb2e3fdc1cbc4a9f2f540c2389f23, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: e32e755643cf50e4185cce56b5a4e662, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 15b78644a499f804183e81b9c8a6bd10, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2729704582954218501, guid: c7feb74161f79644cb6705c448626a40, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: fb56aa5d8f3770241a0163ad51a61037, type: 3}
@@ -245,11 +305,11 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 3476034253fd62f40abadee8fcdf8b42, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 3c97ae79fb0de75489a23bbf55c348d3, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ac7f847fe2e26ce44ad731ebf55adb4f, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: d787f0e2da5add8409c7a4f55f80f365, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: cee84b7aaa9a1e44386166b8b88843d5, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 70195a8ad6ea4b14f965327600bba431, type: 2}
     instantiationMode: 1
@@ -257,17 +317,15 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 37ce6af271e0a754aadfbaa140258581, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 4b7009ba578e2164ebb76d0deb36005c, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 8948cd5589a2d4248b67022fc8a07805, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 27bbf5e14b4ee20489268085cdc599c4, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 646e32d9d84eb1d42bc8547cf5454e86, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: 6d8a67f149c75b74abde6909d8d1b033, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 4dbe68c7c3d212045b675a4cd20d59a7, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 52810c82629488b46b220d0be447d6cc, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 996cfa58592d8db45896d56fe149cb26, type: 2}
     instantiationMode: 1
@@ -283,6 +341,8 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 9100000, guid: 51fd61fc7c04b464c87f3c64a8c39da7, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: f1bdc142b9e80cd4b81057e6ab4b8cab, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: e46911a7a8f2b5f4282238fcefa5aa02, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: ee148e281f3c41c5b4ff5f8a5afe5a6c, type: 3}
@@ -291,11 +351,17 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 3260f7ac7a3e8324ab3acd7ab9901d60, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 5482bde161ea99845873a4a2ad5211fb, type: 2}
+  - dependency: {fileID: 7400000, guid: e52f8863ff667b049ac639fd8b4bbc7a, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 9100000, guid: d476b1b23c3031f469c3be1363b043de, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 3862299384688996026, guid: 5bc4530e0aae8c6469205bb70ca8a30e, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: dfc76d2c2e1daf84ab70b4dc7d33151b, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 60c7a8bf65b8e824a8ae13398ff224a1, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 146a1924f936d5443a26662cc0a58ba5, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: f69358c3541dc2a4f8cb5c49ea1aa7ca, type: 2}
     instantiationMode: 1
@@ -307,22 +373,28 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 6c3fd1d3150b1e44dbce0c46e9542805, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: bbb362122cb3379438d06c0bb7a8b59f, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: e75929b19fef6024c85a7307c022a894, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ccb5a28995455fa4a99219c0c8ecffae, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 22baa4777845d3b4695572f18224dda7, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 463386b0b3b8196428ca3ce469d92828, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: f6c9dc98231779c4585a214258a16bfd, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 0670b74619ef56241bf6899f10915ca5, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 2261462b19c3a904c93e2dafac05c753, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: aef2b1044b0a9a94ab9a7157d787223d, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 5292ed44b75dfc742b51cf5c99198759, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: 1fdb044483244b84fa24164cbc94f4cf, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 2729704582954218501, guid: 1114d94c5bc43b0408607dc81d3641e4, type: 3}
-    instantiationMode: 0
+  - dependency: {fileID: 102900000, guid: 2ea6cf0679abf044a937deb6f6509872, type: 3}
+    instantiationMode: 1
   - dependency: {fileID: 11400000, guid: f83d382b257928b42aaf90ffad4a652f, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 59bec480ab361394380445085f556263, type: 3}
@@ -339,7 +411,7 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: e5620003ae9cd2b4e8116f63e128c826, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: a59100700aa26bc46a76d37e80f89ce1, type: 2}
+  - dependency: {fileID: 2800000, guid: d55cf4b2a553f0244a776df5385e9173, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 04b6c9b33638a4446a47db32871ad11a, type: 2}
     instantiationMode: 1
@@ -347,7 +419,9 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 4b62a78433bd63f4abaad2ab345e3d31, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: 62fc8c0d5a8b84746976c6bdcad17ae9, type: 2}
+  - dependency: {fileID: 7400000, guid: a59100700aa26bc46a76d37e80f89ce1, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 9ec7e0c1fabf7f94182b001a639605fa, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 5d62caeea1f38b44eaedad275b7a4cd4, type: 2}
     instantiationMode: 1
@@ -361,15 +435,15 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 5055d8a1f36030b428aef17a25d8bbd0, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 7f4b74593c5bdf54c9066fdb4f7127da, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 6161d189e427b3a468cb5f6f2dd5d3bc, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: b51d47e8d2560e74ea81c371c9bec8ee, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: dc250de094a35b0438fb16e793b8bbf7, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2729704582954218501, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
+  - dependency: {fileID: 2800000, guid: f409f427f5cd61c478c0cba917e3ff50, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 5655322108261420855, guid: 5f4b1eb2d2208ee42b04d409d30fc617, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: c49c0949b3895114f9ce6823999312fa, type: 2}
     instantiationMode: 0
@@ -391,9 +465,15 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 168b2ce731142c44b950cc30dc82b482, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: d2e470b992f54ac4b93a5ee2bd0ce021, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 250da9c6935833b48b01d71e9895940a, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: d58360e60fa58924995e9e9b7f1b5d8f, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 12800000, guid: e3265ab4bf004d28a9537516768c1c75, type: 3}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: 07f77460871af2a48a5e94444723dfd4, type: 2}
+  - dependency: {fileID: 9208128015413433642, guid: 87fdb55ab56116a489e1342931304cdb, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: f9ade8aa312687245849320231816a73, type: 3}
     instantiationMode: 0
@@ -401,15 +481,21 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 4cefe75266f79af4aa2b7fad58a5a442, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2729704582954218501, guid: 033c9dd47c1c4394fbc3dd24c6294624, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 102900000, guid: 8ab809b0ca77f0e4cae8d2134b6e2add, type: 3}
+    instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 6648666887d69514ba3eaa70aa8f4d2d, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 9100000, guid: fdd461b971a50794fb448b5b8288293e, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ec45c3380edf3a94cb39101072dc4e16, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 1917586413575135466, guid: 84e274db7e5072b42bdf467a668390b9, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: b9598742b56190c4ea24178e52d952ed, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 14deb702f48d33b48aee1c81f73fcc0b, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 5b7e75589bc8ecd44b5eab4d4b0338b6, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 78ce4ff76175e584cb7363bc27a5e68b, type: 2}
     instantiationMode: 1
@@ -417,7 +503,7 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 6119993a988e736448c72aa75d784230, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: 2ace28ab5c0b0344ea1825d70e65f1c5, type: 3}
+  - dependency: {fileID: 7400000, guid: f54e5d25bc017444dbabcfc16b54b43a, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 9ec2c4e64aeefd14e95fd6cfdd3e54cc, type: 3}
     instantiationMode: 0
@@ -428,8 +514,6 @@ MonoBehaviour:
   - dependency: {fileID: 7400000, guid: 37fbd390eeebca0448d6f17d144b37d1, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 65df38c358bd28e408f4f9dd5664318b, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 011094882f2bf34498dd51bf431f2b9e, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: b5a1ec22dd1894c47b488ff01dfe2549, type: 2}
     instantiationMode: 0
@@ -445,15 +529,15 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 61170360ebe8a674cbf0632fcce49ac3, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 1e89efd63cd919d47b4376dfeb60879c, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: 0062bcfe4d956464c92f3afb204f3ab1, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 1e27c670c9c25624d9ef82f52ea3fc3f, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: abbad1a066adeef44898e2b32c9c5ef5, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 0062bcfe4d956464c92f3afb204f3ab1, type: 2}
+  - dependency: {fileID: 2800000, guid: 5b7e75589bc8ecd44b5eab4d4b0338b6, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 778ff82633473aa40b27e69723539e04, type: 3}
     instantiationMode: 0
@@ -469,29 +553,25 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: de010d6908260234589fad480298a594, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 9100000, guid: a7c096d828b3c034bab59889d1c8f944, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 79215b215dc9f074dbd1055cfe528702, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 9c4050f3ede38a649825996ca79aceed, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 5937708875a83514ab713a5a51eedf20, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: aa2042f4894ecaa47af5498c666b1550, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 9670c199d3611cf4786375b1afbef689, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: 8751167108ee07e41ac7577c7f5d261e, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 4511971168175405730, guid: ebdfc3a611f8be04494f5101c01a972a, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 3dc33fe8caa81c14ca963cee36ef1edc, type: 3}
+  - dependency: {fileID: 7400000, guid: 6c62efb3e3a88f04090f0c7075f786c9, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 4187da0bbc6d1f94db3cc662efeecf43, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 4511971168175405730, guid: ebdfc3a611f8be04494f5101c01a972a, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 289a063844973484880c9c82e0872a52, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: f7d5c000f4f5d974fbb96174dabe7ffe, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 967d8250bd67f5247aa9d2cb1079fad5, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 8be6e3bced5dabb4cbd4b2225872d261, type: 2}
     instantiationMode: 0
@@ -503,33 +583,41 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 4bd57b74aba6e364eba8780d93ed7594, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: f253ad14c8244a94db4772249269f2b2, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 0222a108185d9654790ef2357b2faa01, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 9100000, guid: 67d908743b262df4ba47ce8d98432da4, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: cc4844901e2a5f6478d6e08fd5af10fe, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: f9969768bfa81a54b9efd0805674b063, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 9100000, guid: 67d908743b262df4ba47ce8d98432da4, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 7308578583151455641, guid: 4c66e3bdbb5159c499e1eaf3c6424e88, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: 94883b0cac28cf04684eb48bab8514ce, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 7fd44834b6ce7f64c8479a26226f18aa, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 5d001a6cac2bba74d96888747a581ec4, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 9179dd664374f3d4fa418420d18e10f6, type: 3}
-    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: e8af90376d6196f4e936134bbde781a2, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 57c898ef0d935fb49a3211a6c3a27630, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 1917586413575135466, guid: c5477eafd6a4f7547b87210c1b97f79b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 2cedfc33d88b08d4bba7223833218f2a, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: e71170acb79069a4799734f87b1dfd60, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 9100000, guid: 82b955cebcbedca4a8da53c705c114f0, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: a0b399879af219d498d3146b8a0ecfb6, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: a4ea380779078384d9e04faed64dd75d, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: 0222a108185d9654790ef2357b2faa01, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 846eb02dde3f5f04d92adadd4cdedb2e, type: 3}
     instantiationMode: 0
@@ -539,15 +627,13 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 102900000, guid: 7632129422bcf37479837ddc784c8b73, type: 3}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: 798138f0fef8a8241a5c1d8365ad3be8, type: 2}
+  - dependency: {fileID: 11400000, guid: e046e5c585708f84381219bee577ad33, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: fb7e887c002376d46a642cfdf45b73d0, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 40d0b7544bb58db409fb1d2c51e5639f, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 1566437fce11f5d49919e875b9c98689, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: ac00775c8fa16d84fb25aef81d86e94b, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 9100000, guid: 9aed360f321b8c14b8ba64d8658767c2, type: 2}
+  - dependency: {fileID: 7400000, guid: 798138f0fef8a8241a5c1d8365ad3be8, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 9ed1d357508f5824e8dca6c115aa19c0, type: 3}
     instantiationMode: 0
@@ -561,9 +647,13 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 7aa1413113786024490f67368a6a3e9c, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 6e246242ac0e98841b6010b68d403e62, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 23800000, guid: 0aff6e0980969b0438251b672895fedf, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 7400000, guid: bb65b289bed4d1443ad47cda828cc5f8, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 6e246242ac0e98841b6010b68d403e62, type: 3}
+  - dependency: {fileID: 2800000, guid: 49b7e1b868f9ca74fbebb072cfcc099e, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: fd1fb9d32a86ea64a94bb5310669a3cd, type: 2}
     instantiationMode: 1
@@ -577,13 +667,9 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: e1384e55cf3ae8440935cbba68455d13, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: f67601c1bfcd8e04082c29d298578b25, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 8111385526fa0264b8af1db133febf90, type: 3}
+  - dependency: {fileID: 7400000, guid: 7830743f11ac7254787da7f471c73f04, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 21a36849982f983408e80a0723fa48da, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: f3057248c6ff98045ab9cc4563b8a136, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 3bc51ce6a0f2bf542aebbd5708d3b7e7, type: 3}
     instantiationMode: 0
@@ -591,25 +677,33 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: f39cfc85f250fde44b74b1a44fbe50a7, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 6f85a19b855920a4f935dd8008aaadb1, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 3899918724569210240, guid: ddc575e6ffdb3aa408762e1c18fa5600, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: d3de4387672da174ca1c6d55e2bbbe23, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 62e7490cd42c69641858e5619cce349a, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: b80e172b61c4d1640a7f789d88d39cec, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: e67ef5d9874556e40a9075f1ac453a73, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 9ca6d37d4d59ac04698518a78c5f4912, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: c4631b914a24d1245beed006e53d5e26, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: a2b3432fb9fffec46bb3c64f29bc9c46, type: 3}
+  - dependency: {fileID: 7400000, guid: 54be3acf1d26e1448ab77c70990e0ef8, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 973651c9efb5fa247831b3054baab619, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 7400000, guid: 3f7562f12d19f7c498a5dd7157907b72, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: a2b3432fb9fffec46bb3c64f29bc9c46, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2729704582954218501, guid: afbc20ec6ff747345aef001a13cbfc14, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: b0c3603d730b66c43870415733a250c5, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 2ede0b60bd502f34db63001ca87a3c06, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 9100000, guid: 5251e483c064200459f4fc8ead48e5d2, type: 2}
     instantiationMode: 0
@@ -621,9 +715,11 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 3b58b9be7d04ea948a7986f4e15c3d45, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 9100000, guid: 649f93f2d3054c64b86cc72039c601ec, type: 2}
+  - dependency: {fileID: 2800000, guid: 44d8c8483429daa41824220e8786cae8, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 9100000, guid: 0fd59e6bca4d09a4a92a92c59d9a0336, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 9100000, guid: 649f93f2d3054c64b86cc72039c601ec, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: cbfe86bb96576134188aacc987cb013b, type: 3}
     instantiationMode: 0
@@ -631,9 +727,17 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 162c5000980f7874d95a4c5f6cd0865c, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 11400000, guid: 30c69d1338fcec340ba727f6fea84982, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: e7cb3669aa2308f4caa25656dc527b3b, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 2f9b044242f464e4cab770e59b2e1d35, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 9c76c6f7d4b1bd347b6dba5f876e1acf, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: a70c9d00a98c1654aa512ea92f78cb63, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 0a2c958e61af1f34686933213b3b7117, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 8af639cc8bb520c46890f00bba189f04, type: 3}
     instantiationMode: 0
@@ -644,6 +748,10 @@ MonoBehaviour:
   - dependency: {fileID: 11400000, guid: ed093b865d3ccbd4dbf68c687bad1331, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 41afceb3fa7173848ab86f567dba6aee, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 4511971168175405730, guid: afa838eac547d2647b13abd6612e560a, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 9100000, guid: 3e4c0667c7d071d4aba23f9dd4ac983a, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 2d72306de88438d4abb3c3210ba0450c, type: 3}
     instantiationMode: 0
@@ -657,6 +765,8 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 01906788355fc3a438d15ddecb364bed, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 44279115a75965240872558ebbf14a30, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: fc2c56c91865dae4fbff8c9ccd1ab0aa, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 55bd2e1130c119d4986cb37d479a873c, type: 3}
@@ -669,21 +779,25 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: f39a56038dd829342b7c26908ccba814, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 3508701ff6d95b14db1ad219e45db50d, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 2729704582954218501, guid: 79c81f235e96e5342bcf8c81fb446fec, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: ae212f84be419764ba169617f05e2469, type: 2}
+  - dependency: {fileID: 7400000, guid: b77ab0d162896344480d8509b5a96a38, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 9272791d57ec8484bae9d20dcc6cd01f, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 1d5a312317186eb418af23f1e09ac6a2, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: ae212f84be419764ba169617f05e2469, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 4178a40a2739fe943b7c5468f9efea0c, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 16c9b60fe9d99b94abf6640d4a8ff029, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 767a280a48ea14e4a821affde77e64d3, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 53418f661724ce544a9ee409413ef9d2, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: e761d46b9110f814abde9c9b0e6a964c, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 2c2b6101806b6bf468555cc2435a40d7, type: 2}
     instantiationMode: 0
@@ -691,15 +805,23 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 6b5bdb36cb769144fabfaeb6fa6c87ed, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 9100000, guid: 955661eaa0218e446be8f95761d8f934, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 273c8b5db6e39534781066db3444fe88, type: 3}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 872e71cc8d6d50f48bdf162a122e3e55, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 743eb248df4bdfa49a028560f826490e, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: 9f0a54afdb7e2474b8d21adece448907, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: f3af2907a8cdc69488ba2a0d11fcd07b, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 11d62f60652eaf646964d40ffc258005, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 867650870b5e19d4fa1b84570c821336, type: 3}
+  - dependency: {fileID: 7400000, guid: 8affd5a5362db9c4895fbc21f81c8f9e, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 4a7cf28a713301c449a9be00ebd83680, type: 2}
+  - dependency: {fileID: 2800000, guid: 6fa5a5f4f9c52304e94e64196ab4ad6e, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 8ef86eaa217e71e4090d5ed6110f5488, type: 3}
     instantiationMode: 0
@@ -707,36 +829,54 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: f29ab975b281775448b66d6dac20a903, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: a2f9725ab072bac4bb7dfb1dbe2b8007, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 5f9d598a231d4a04bb3a8d17731a63a4, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 46e5b10fb2c29cf4392743c61a4499ba, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: f131acc0ad1595d43887faf0d78c623f, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 7400000, guid: ee985c083d461c043b2f90314c4b82e2, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 5e90afd2ac02bb94d905e4e40a86ced3, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: d2e9286d75e688942925728adc073e01, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: da14cb2d2add423429a35c6953a585f4, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: a5eed99127d194344b63a81160f27ee5, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 24805021ab797504b8b32317b84d8baf, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 92885a6789fb37c4c9423b409448ea09, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 8f25030f778319c4ab328334c1314905, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 9ece18179b73aee4f897d76466637229, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: eaaecc641b6d28d41a226f052ed5dc64, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: a9ddb3bc60c3959468e1f62a95090025, type: 3}
+  - dependency: {fileID: 7400000, guid: d292d706b0b6f3c4095ee97be0360083, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 819afadb85c96134d8cf55432f2fa10c, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 7e3a9196c3a7fd64d968446695096add, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 7c069c931f5946048b88b2597fe80921, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2729704582954218501, guid: d6c76f14b4dfe664abc96ae692e0fe8b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 136e2837a35c2d0428bac9513ebd4d58, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: f8f1bc653172a2a4b937379238f1664f, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: a9ddb3bc60c3959468e1f62a95090025, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: c951507d5c65a164b8a824eb44358ad0, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 8fb054b7c7b01c44883eee5ddbd6ddb5, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 19b9e4b83ccb35d40b5ac0d6d49a7a64, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: adca1558f5037244196351d0b1dd0ab5, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: a7e53d7ad6db3b24789b1ba14c42d360, type: 3}
@@ -751,11 +891,13 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 5d1865709482bae4e8057b17530e18ad, type: 2}
     instantiationMode: 1
-  - dependency: {fileID: 2800000, guid: 5db54fd12da90b147b9e79a6086f3af9, type: 3}
+  - dependency: {fileID: 7400000, guid: 0268f864b7bf85c4393188514e840cee, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 99d358c45dff89b4eba2f4f751092e69, type: 2}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 46e6b1b8fe174f34983efe7870ac0e48, type: 3}
+  - dependency: {fileID: 2800000, guid: 8eed71e8194ef024e9a5872ded57e16c, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 08c4e8e481886984f93d178d08ed73c2, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: a325b028652272a47bf11de52a957f64, type: 3}
     instantiationMode: 0
@@ -777,9 +919,13 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 3d010155650453a4f8671f7fc51e6015, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: d83da298902458242bd8ef79c7dba79a, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ff11db16a45928246b4de1a506d4efc8, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: c5b2a0409f9f8454599bf9b851e217c5, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 7400000, guid: 845e04c8d30f712408059ed12af1d069, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 4511971168175405730, guid: 2b09465edfa8fef42bab1be7260b319b, type: 3}
     instantiationMode: 0
@@ -787,7 +933,11 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: b9bb18faf28b4b341843b8e4ecec8c75, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: ceb5b6fe9bad3e940b3b6b29dddf2997, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 7400000, guid: 80de784c2ce28fc4f9295b20808457a9, type: 2}
+    instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: 3719f61d552bad249be5a77160fe3f67, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: aadcd7b5268728f4c8862649539373da, type: 2}
     instantiationMode: 1
@@ -801,9 +951,15 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 7c99a198a98257541955c2d03590d528, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 0fdade046c0c66642938099ad6541955, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: ab0071d93a551cf42847a569376edd58, type: 3}
     instantiationMode: 0
+  - dependency: {fileID: 2800000, guid: ab5bbd0dafb62aa4ca01f61291c9e4b8, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 50bed8f3b0ed15249af70df664f680ae, type: 3}
+    instantiationMode: 0
+  - dependency: {fileID: 9100000, guid: 583d9ed7d72550d4cab686f83a21690a, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: af5ceafb390d6374294763efb323f110, type: 2}
     instantiationMode: 1

--- a/Assets/Scripts/Player/Inventory.cs
+++ b/Assets/Scripts/Player/Inventory.cs
@@ -27,6 +27,11 @@ namespace Player
             }
 
             Debug.Log($"Now you have {_items[item]}x {item.itemName}");
+            
+            if (PlayerData.Instance != null)
+            {
+                PlayerData.Instance.AddItem(item, quantity);
+            }
         }
 
         // Uses an item and applies its effect to the player
@@ -36,6 +41,14 @@ namespace Player
                 return false;
 
             _items[item]--;
+            
+            if (PlayerData.Instance != null)
+            {
+                if (PlayerData.Instance.inventory.ContainsKey(item))
+                {
+                    PlayerData.Instance.inventory[item] = _items[item];
+                }
+            }
 
             switch (item.effectType)
             {

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -7,6 +7,8 @@ using Items;
 using Player.State;
 using UnityEngine;
 using Weapons;
+using System.Collections.Generic;
+using Systems;
 
 namespace Player
 {
@@ -78,6 +80,16 @@ namespace Player
         {
             // Set initial player state to idle
             _stateMachine.Initialize(IdleState);
+            
+            if (PlayerData.Instance != null)
+            {
+                var itemsToLoad = new Dictionary<ItemSO, int>(PlayerData.Instance.inventory); // Copia segura
+
+                foreach (var item in itemsToLoad)
+                {
+                    Inventory.AddItem(item.Key, item.Value);
+                }
+            }
         }
 
         void Update()

--- a/Assets/Scripts/Player/PlayerData.cs
+++ b/Assets/Scripts/Player/PlayerData.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Items;
+
+public class PlayerData : MonoBehaviour
+{
+    public static PlayerData Instance { get; private set; }
+
+    [Header("Vida del jugador")]
+    public int currentHealth;
+    public int maxHealth;
+
+    [Header("Inventario del jugador")]
+    public Dictionary<ItemSO, int> inventory = new();
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void AddItem(ItemSO item, int quantity)
+    {
+        if (!inventory.ContainsKey(item))
+            inventory[item] = 0;
+        inventory[item] += quantity;
+    }
+
+    public int GetItemCount(ItemSO item)
+    {
+        return inventory.ContainsKey(item) ? inventory[item] : 0;
+    }
+
+    public bool HasKey(string keyID)
+    {
+        foreach (var pair in inventory)
+        {
+            if (!string.IsNullOrEmpty(pair.Key.keyID) && pair.Key.keyID == keyID && pair.Value > 0)
+                return true;
+        }
+        return false;
+    }
+}

--- a/Assets/Scripts/Player/PlayerData.cs.meta
+++ b/Assets/Scripts/Player/PlayerData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1afa33047bb7d02468b9144b4fa56f87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -28,6 +28,10 @@ namespace Player
         {
             Heal(amount);
             StartCoroutine(FlashGreen());
+
+            // Guardar salud actual
+            if (PlayerData.Instance != null)
+                PlayerData.Instance.currentHealth = _currentHealth;
         }
 
         // Called when player takes damage (includes visual feedback)
@@ -35,6 +39,10 @@ namespace Player
         {
             base.TakeDamage(amount);
             StartCoroutine(FlashRed());
+
+            // Guardar salud actual
+            if (PlayerData.Instance != null)
+                PlayerData.Instance.currentHealth = _currentHealth;
         }
 
         // Coroutine to flash red briefly when damaged
@@ -89,6 +97,12 @@ namespace Player
                 spriteRenderer = GetComponent<SpriteRenderer>();
 
             _originalColor = spriteRenderer.color;
+            // Cargar vida desde PlayerData
+            if (PlayerData.Instance != null)
+            {
+                _maxHealth = PlayerData.Instance.maxHealth;
+                _currentHealth = PlayerData.Instance.currentHealth;
+            }
         }
     }
 }


### PR DESCRIPTION
- Se implementó el singleton `PlayerData`, persistente entre escenas mediante DontDestroyOnLoad.
- Guarda salud actual y máxima del jugador, así como su inventario de ítems (tipo ItemSO y cantidad).
- Se actualizó `PlayerHealth` para sincronizar salud con `PlayerData` al recibir daño o regenerarse.
- Se modificó `Inventory.AddItem()` y `UseItem()` para reflejar los cambios directamente en `PlayerData.Instance.inventory`.
- En `Player.cs`, se agregó la carga del inventario desde PlayerData al iniciar la escena.
- Se corrigió un error de modificación concurrente al iterar sobre el inventario copiándolo previamente (`InvalidOperationException`).
- Se corrigió el error de compilación agregando `using System.Collections.Generic;` para habilitar el uso de Dictionary<>.

Este commit asegura que el jugador conserve sus ítems y su salud al cambiar de escena, sin necesidad de mantener el objeto del jugador activo entre escenas.